### PR TITLE
Fix how the nonce is retrieved

### DIFF
--- a/src/actions/dot/forceTransfers.ts
+++ b/src/actions/dot/forceTransfers.ts
@@ -41,7 +41,7 @@ export const forceTransfers = async (cmd: Command) => {
     throw Error("This is not the secret for the Sudo key.");
   }
 
-  const startingNonce = await api.query.system.accountNonce(sudoKey.address);
+  const startingNonce = (await api.query.system.account(sudoKey.address)).nonce;
   let counter = 0;
   for (const entry of csvParsed) {
     const [dest, amount] = entry;


### PR DESCRIPTION
We talked about it live :)
This PR fixes the issue that can be reproduced running the following:

## node:
`docker run --rm -it --name polkadev -p 9944:9944 chevdor/polkadot:0.8.2 polkadot --dev --alice --rpc-cors all --unsafe-ws-external`

## command
`y force-transfers --csv alice_to_bcdef.csv --wsEndpoint ws://localhost:9944 --suri //Alice --source 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY``

NOTE: the content of the CSV does not matter. I am using the following to send from Alice some tokens to Bob, Charlie, etc... resp. 1, 2, 3, etc... (irrelevant)
```
5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty,1000000000000
5FLSigC9HGRKVhB9FiEo4Y3koPsNmBmLJbpXg2mp1hXcS59Y,2000000000000
5FLSigC9HGRKVhB9FiEo4Y3koPsNmBmLJbpXg2mp1hXcS59Y,3000000000000
5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy,4000000000000
5HGjWAeFDfFCWPsjFQdVV2Msvz2XtMktvgocEZcCj68kUMaw,5000000000000
5CiPPseXPECbkjWCa6MnjNokrgYjMqmKndv2rSnekmSK2DjL,6000000000000
```

## Error before PR:

```
TypeError: api.query.system.accountNonce is not a function
    at /Users/will/.config/yarn/global/node_modules/@w3f/injection-tool/lib/src/actions/dot/forceTransfers.js:71:50
    at Generator.next (<anonymous>)
    at fulfilled (/Users/will/.config/yarn/global/node_modules/@w3f/injection-tool/lib/src/actions/dot/forceTransfers.js:24:58)
    at processTicksAndRejections (internal/process/task_queues.js:86:5)
```
