### PR TITLE
Add ability to change vesting schedule injection

### DIFF
--- a/src/actions/dot/batchFVT.ts
+++ b/src/actions/dot/batchFVT.ts
@@ -31,6 +31,10 @@ export const batchVestedTransfer = async (opts: Options) => {
     perBlock,
   } = opts;
 
+  if (perBlock !== 'auto' && perBlock !== 'all') {
+    throw new Error(`--perBlock must be set to either auto or all | Set: ${perBlock}`);
+  }
+
   const input = parseCsv(csv);
   const api = await initApi(wsEndpoint, types);
   const keyring = new Keyring({ type: cryptoType });

--- a/src/actions/dot/batchFVT.ts
+++ b/src/actions/dot/batchFVT.ts
@@ -15,6 +15,7 @@ type Options = {
   types: any;
   wsEndpoint: string;
   startingBlock: string;
+  perBlock: "auto" | "all";
 };
 
 export const batchVestedTransfer = async (opts: Options) => {
@@ -27,6 +28,7 @@ export const batchVestedTransfer = async (opts: Options) => {
     types,
     wsEndpoint,
     startingBlock,
+    perBlock,
   } = opts;
 
   const input = parseCsv(csv);
@@ -41,12 +43,10 @@ export const batchVestedTransfer = async (opts: Options) => {
   const calls = input.map((entry: any) => {
     const [dest, amount] = entry;
 
-    const perBlock = w3Util.toBN(amount).divRound(VestingLength);
-
     const vestedTransfer = api.tx.vesting.forceVestedTransfer(source, dest, {
       locked: amount,
-      perBlock,
-      startingBlock: 0,
+      perBlock: perBlock === 'auto' ? w3Util.toBN(amount).divRound(VestingLength) : amount;
+      startingBlock: Number(startingBlock) || 0,
     });
     const sudoCall = api.tx.sudo.sudo(vestedTransfer);
     const proxyCall = api.tx.proxy.proxy(sudo, "any", sudoCall);

--- a/src/index.ts
+++ b/src/index.ts
@@ -112,6 +112,8 @@ program
   .option('--suri <suri>', 'Pass in the suri for the Sudo key.')
   .option('--types <json>', 'A JSON configuration of types for the node.', '{}')
   .option('--wsEndpoint <url>', 'The endpoint of the WebSockets to connect with.', 'wss://rpc.polkadot.io')
+  .option('--startingBlock <num>', 'The block to start the linear vesting.', '0')
+  .option('--perBlock <[all,auto]>', 'How to calculate perBlock. auto: standard 2 year schedule, all: single block unlock', 'auto')
   .action((cmd) => errorCatcher(cmd, batchVestedTransfer));
 
 program


### PR DESCRIPTION
Adds in `--startingBlock <num>` and `--perBlock <[auto, all]>`.

Setting `--perBlock auto` does the standard two-year vesting schedule.

Setting `--perBlock all` does one-block unlock (to be used in conjunction with `--startingBlock ...` to create cliffs).